### PR TITLE
:lipstick: Fix typos in FAQs

### DIFF
--- a/faqs.njk
+++ b/faqs.njk
@@ -36,7 +36,7 @@ eleventyNavigation:
   <a class="direct-link" href="#who-created-penpot-why">#</a>
 </h3>
 <p>
-  There is a company called <a href="https://kaleidos.net" target="_blank">Kaleidos Open Source</a> that has been long known for its commitment to free & open source software and a more diverse and inclusive workplace where cross-domain teams really enjoy working together. Kaleidos launched Taiga [https://taiga.io] a few years ago to deal with the absence of a truly agile open source project management tool. The next major pain in our ranked list of outrageous open source absentees was a design & prototype tool the likes of Figma, Sketch or Invision.
+  There is a company called <a href="https://kaleidos.net" target="_blank">Kaleidos Open Source</a> that has been long known for its commitment to free & open source software and a more diverse and inclusive workplace where cross-domain teams really enjoy working together. Kaleidos launched <a href="https://taiga.io" target="_blank">Taiga</a> a few years ago to deal with the absence of a truly agile open source project management tool. The next major pain in our ranked list of outrageous open source absentees was a design & prototype tool like Figma, Sketch or Invision.
 </p>
 <p>
   At Kaleidos we believe that the tools that we use to build end products should be as accessible to everyone, regardless of their background, skills or purchasing power. Also, not having a free & open source UX/UI tool that would make devs participate in the design process and bridge the gap between UX/UI and code was a terrible itch for us.
@@ -69,10 +69,10 @@ eleventyNavigation:
   <a class="direct-link" href="#why-svg-as-its-native-format">#</a>
 </h3>
 <p>
-  SVG, Scalar Vector Graphics is a widely used Open Standard by the <a href="https://www.w3.org/TR/SVG2/" target="_blank">W3C</a>. It permeates the web, the mobile world and visualisation outputs across a myriad of platforms.
+  SVG (Scalar Vector Graphics) is a widely used Open Standard by the <a href="https://www.w3.org/TR/SVG2/" target="_blank">W3C</a>. It permeates the web, the mobile world and visualisation outputs across a myriad of platforms.
 </p>
 <p>
-  Embracing SVG was a technical challenge but it was a huge opportunity too. It makes a Penpot design, itself valid code already. Moreover, the potential for integrations and interoperability are infinite.
+  Embracing SVG was a technical challenge but it was a huge opportunity too. It makes a Penpot design itself valid code already. Moreover, the potential for integrations and interoperability are infinite.
 </p>
 <p>
   When you are certain that a part of your design is SVG and you live-export that SVG as part of your code repository, you can have back and forth changes through the SVG files. Also, a “continuous design” process could be finally at hand.
@@ -84,7 +84,7 @@ eleventyNavigation:
 
 
 <h3 id="why-is-penpot-different-from-proprietary-products" class="secondary-title">
-  Why is Penpot different from [X proprietary product]
+  Why is Penpot different from [X proprietary product]?
   <a class="direct-link" href="#why-is-penpot-different-from-proprietary-products">#</a>
 </h3>
 <p>
@@ -129,7 +129,7 @@ eleventyNavigation:
   We couldn’t wait any longer. Back in February 2020 we promised that it would take as a year to develop a sort of 1.0. The “alpha” tag might be misleading, it’s quite stable and feature-rich but in some ways it’s still immature with regards to our vision.
 </p>
 <p>
-  Anyway, enjoy it as what it is, the first public iteration of our hopeful plans.
+  Anyway, enjoy it for what it is, the first public iteration of our hopeful plans.
 </p>
 
 
@@ -166,7 +166,7 @@ eleventyNavigation:
   <a class="direct-link" href="#how-to-download-and-install">#</a>
 </h3>
 <p>
-  Current private Penpot instances are only requiring basic Docker knowledge. You can run your own Penpot server following these instructions.
+  Current private Penpot instances are only requiring basic Docker knowledge. You can run your own Penpot server following these instructions:
 </p>
 <p>
   <a href="https://help.penpot.app/developer-guide/configuration/">https://help.penpot.app/developer-guide/configuration/</a>
@@ -246,10 +246,10 @@ eleventyNavigation:
   <a class="direct-link" href="#how-share-designs-with-external-stakeholders">#</a>
 </h3>
 <p>
-  If you want to have a shareable URL to show your designs you can do it from the <VIEWER> mode. Launch it using the <PLAY> button at the top right of the file, there you'll find a <SHARE URL> button to create the link. Copy and send that link for other people to access the design.
+  If you want to have a shareable URL to show your designs you can do it from the VIEW mode: launch it using the PLAY button at the top right of the file, and you'll find a SHARE URL button to create the link at the top right. Copy and send that link for other people to access the design.
 </p>
 <p>
-  You can always invalidate a shared URL if you don’t wish to continue to make it accessible through such link.
+  You can always invalidate a shared URL if you don’t wish to continue to make it accessible through that link.
 </p>
 
 
@@ -259,12 +259,12 @@ eleventyNavigation:
   <a class="direct-link" href="#how-to-stay-up-to-date-with-penpot-news">#</a>
 </h3>
 <p>
-  How or where can I stay up-to-date with the latest Penpot news and what's to come? We will be sharing our progress and news through different channels:
+  We will be sharing our progress and news through different channels:
 </p>
 <ul>
   <li>Penpot Social Networks: <a href="https://twitter.com/penpotapp" target="_blank">Twitter</a>, <a href="https://fosstodon.org/@penpot/" target="_blank">Mastodon</a>, <a href="https://www.instagram.com/penpotapp/" target="_blank">Instagram</a>, <a href="https://www.linkedin.com/company/penpot/" target="_blank">Linkedin</a>. </li>
   <li><a href="https://www.youtube.com/channel/UCAqS8G72uv9P5HG1IfgnQ9g" target="_blank">Penpot Youtube channel</a>: Subscribe to get updates when we upload new Penpot tutorials, demos of features and talks.</li>
-  <li><a href="https://penpot.app/#newsletter" target="_blank">Newsletter</a>: Don’t miss the important stuff subscribing to our low-traffic newsletter.</li>
+  <li><a href="https://penpot.app/#newsletter" target="_blank">Newsletter</a>: Don’t miss the important stuff by subscribing to our low-traffic newsletter.</li>
   <li><a href="https://github.com/penpot/penpot" target="_blank">Penpot Github Project</a>: Follow us to keep up to date with the project progress and get involved in the discussions.</li>
 </ul>
 
@@ -288,7 +288,7 @@ eleventyNavigation:
   <a class="direct-link" href="#how-use-penpot-with-inkscape">#</a>
 </h3>
 <p>
-  Inkscape is a very powerful Open Source vector drawing tool. At Penpot we use it daily for our SVG creations. A very common use we make is to use Inkscape to work with vector illustrations, icon sets and other graphic assets. Then we import them into Penpot to create more complete and visually attractive interface designs. There are other tools that can complete your workflow such as Quant-UX which is very good to learn about your users’ interactions with your product.
+  Inkscape is a very powerful Open Source vector drawing tool. At Penpot we use it daily for our SVG creations. A very common use case we have is to use Inkscape to work with vector illustrations, icon sets and other graphic assets, before importing them into Penpot to create more complete and visually attractive interface designs. There are other tools that can complete your workflow, such as Quant-UX, which is very good for learning about your users’ interactions with your product.
 </p>
 
 
@@ -308,7 +308,7 @@ eleventyNavigation:
   <a class="direct-link" href="#how-can-contribute">#</a>
 </h3>
 <p>
-  We are working on a comprehensive guide on how to contribute to Penpot. There are many ways this can be achieved. Designs, code, testing, reporting bugs, improving documentation, sharing Penpot designs with #MadeWithPenpot, translating Penpot to your favourite language, set up training sessions, etc.
+  We are working on a comprehensive guide on how to contribute to Penpot. There are many ways this can be achieved. Designs, code, testing, reporting bugs, improving documentation, sharing Penpot designs with #MadeWithPenpot, translating Penpot to your favourite language, setting up training sessions, etc.
 </p>
 <p>
   For now, we have a rather limited <a href="https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md" target="_blank">contribution guide</a> that you can already use but we plan to improve this very soon.
@@ -322,13 +322,13 @@ eleventyNavigation:
 </h2>
 <p>
 <p class="main-paragraph">
-  Here we include some other interesting questions people have asked or we would like to directly address.
+  Here we include some other interesting questions people have asked or that we would like to directly address.
 </p>
 
 
 
 <h3 id="roadmap-short-mid-term" class="secondary-title">
-  What is in Penpot’s roadmap for the short-mid term?
+  What is in Penpot’s roadmap for the short-/mid-term?
   <a class="direct-link" href="#roadmap-short-mid-term">#</a>
 </h3>
 <p>
@@ -355,5 +355,5 @@ eleventyNavigation:
   Short answer would be no, we do not keep things from improving because of the potential loss of familiarity.
 </p>
 <p>
-  It is true that we are using known patterns to ease the learning curve, this is part of Penpot’s strategy. Given that, we could say that “familiar” is included in our definition of success, but this might be for a different, also interesting, conversation. We do not hide that we have kept an eye not only on Figma but also on many others “usual suspects” (Sketch, Adobe XD, Inkscape, Webflow, Blender...) to study common patterns. However, our design decisions are based not only on previous research but also on testing solutions with users. Therefore, if we were to find that something works better for us in a different way, we’d go for it. Masks and toolbars are some examples of this approach.
+  It is true that we are using known patterns to ease the learning curve, this is part of Penpot’s strategy. Given that, we could say that “familiar” is included in our definition of success, but this might be for a different, also interesting, conversation. We do not hide that we have kept an eye not only on Figma but also on many other “usual suspects” (Sketch, Adobe XD, Inkscape, Webflow, Blender...) to study common patterns. However, our design decisions are based not only on previous research but also on testing solutions with users. Therefore, if we were to find that something works better for us in a different way, we’d go for it. Masks and toolbars are some examples of this approach.
 </p>


### PR DESCRIPTION
:lipstick: Fix typos in FAQs

I fixed a few typos in the docs. Didn't do [DCO](https://github.com/penpot/penpot/blob/develop/CONTRIBUTING.md#developers-certificate-of-origin-dco) as this only seems required for code. 