### PR TITLE
Guide how to integrate with Azure Active Directory

### DIFF
--- a/technical-guide/configuration.md
+++ b/technical-guide/configuration.md
@@ -158,6 +158,18 @@ Since version 1.6.0:
 PENPOT_OIDC_SCOPES="scope1 scope2"
 ```
 
+#### Azure Active Directory using OpenID Connect
+
+Allows integrating with Azure Active Directory as authentication provider:
+
+```bash
+# Backend & Frontend
+PENPOT_OIDC_CLIENT_ID=<client-id>
+
+## Backend only
+PENPOT_OIDC_BASE_URI=https://login.microsoftonline.com/<tenant-id>/v2.0/
+PENPOT_OIDC_CLIENT_SECRET=<client-secret>
+```
 
 ### LDAP ###
 

--- a/technical-guide/configuration.md
+++ b/technical-guide/configuration.md
@@ -75,10 +75,7 @@ https://<your_domain>/api/auth/oauth/gitlab/callback
 
 #### Google
 
-Allow use google as oauth provider:
-
-
-On backend:
+Allows integrating with Google as OAuth provider:
 
 ```bash
 # Backend & Frontend
@@ -88,9 +85,9 @@ PENPOT_GOOGLE_CLIENT_ID=<client-id>
 PENPOT_GOOGLE_CLIENT_SECRET=<client-secret>
 ```
 
-#### Gitlab
+#### GitLab
 
-Allows use gitlab as oauth provider:
+Allows integrating with GitLab as OAuth provider:
 
 ```bash
 # Backend & Frontend
@@ -101,10 +98,9 @@ PENPOT_GITLAB_BASE_URI=https://gitlab.com
 PENPOT_GITLAB_CLIENT_SECRET=<client-secret>
 ```
 
-#### Github
+#### GitHub
 
-Allows use github as oauth provider:
-
+Allows integrating with GitHub as OAuth provider:
 
 ```bash
 # Backend & Frontend
@@ -118,8 +114,8 @@ PENPOT_GITHUB_CLIENT_SECRET=<client-secret>
 
 **NOTE:** Since version 1.5.0
 
-Allow integrate with a generic authentication provider that implements
-the OIDC protocol (usualy used for SSO).
+Allows integrating with a generic authentication provider that implements
+the OIDC protocol (usually used for SSO).
 
 All the other options are backend only:
 


### PR DESCRIPTION
Azure Active Directory documentation uses slightly different parameters than Penpot configuration for OpenID Connect integration. Even though client-id and client-secret are shared, I needed to look at Penpot source code to understand how base-uri and tenant-id relate to each other. For this very reason, I think it is worth including it in the documentation.

Moreover, I have fixed grammar and typos in authentication providers names.

