### PR TITLE
Fix localhost port (8080) for Eleventy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ And launch a development server:
 npm start
 ```
 
-You can then point a browser to [http://localhost:8081](http://localhost:8081).
+You can then point a browser to [http://localhost:8080](http://localhost:8080).
 
 
 ## Tooling


### PR DESCRIPTION
Actually it was my first time to use Eleventy, so I am not sure why it was `8081` in `README.md`.

The script in `package.json` is `eleventy --serve`, and the default port is `8080` according to its homepage.
This change really worked well for me.

Signed-off-by: snack <rollingsnack831@gmail.com>