### PR TITLE
Fix instagram link

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -94,7 +94,7 @@
         </ul>
         <ul class="footer-block">
           <li><a href="https://twitter.com/penpotapp" target="_blank">Twitter</a></li>
-          <li><a href="https://instagram.com/penpotapp" target="_blank">Instagram</a></li>
+          <li><a href="https://instagram.com/penpotapp/" target="_blank">Instagram</a></li>
           <li><a href="https://github.com/penpot" target="_blank">Github</a></li>
           <li><a href="https://www.linkedin.com/company/penpot/" target="_blank">Linkedin</a></li>
           <li><a href="https://www.youtube.com/channel/UCAqS8G72uv9P5HG1IfgnQ9g" target="_blank">Youtube</a></li>


### PR DESCRIPTION
Every now and then, Instagram shows an error when opening a profile page without a / at the end ("Oops, an error occurred. ").