### PR TITLE
fix backend container name

### DIFF
--- a/technical-guide/getting-started.md
+++ b/technical-guide/getting-started.md
@@ -68,7 +68,7 @@ need to create a user in order be able login into the application. You
 can create an additional, already activated user using this command:
 
 ```bash
-docker exec -ti penpot_penpot-backend_1 ./manage.sh create-profile
+docker exec -ti penpot-penpot-backend-1 ./manage.sh create-profile
 ```
 
 In general, the application is ready to be used without email


### PR DESCRIPTION
It appears the configuration command is using some underscores in the container name, but the container name does not have any underscores.
![image](https://user-images.githubusercontent.com/6669245/158039973-da04bb10-8ea9-43ee-8806-f2996be9ee88.png)


