### PR TITLE
Update name of container in create user command

### DIFF
--- a/technical-guide/getting-started.md
+++ b/technical-guide/getting-started.md
@@ -68,7 +68,7 @@ need to create a user in order be able login into the application. You
 can create an additional, already activated user using this command:
 
 ```bash
-docker exec -ti penpot-penpot-backend-1 ./manage.sh create-profile
+docker exec -ti penpot_penpot-backend_1 ./manage.sh create-profile
 ```
 
 In general, the application is ready to be used without email


### PR DESCRIPTION
The current create user command references a container created automatically by the docker-compose command given earlier in the document but there is an error in the name. PR changes command to reflect the name of the generated container.