### PR TITLE
Adds required args to documentation of `./manage.sh create-profile`

### DIFF
--- a/technical-guide/getting-started.md
+++ b/technical-guide/getting-started.md
@@ -124,7 +124,7 @@ need to create a user in order be able login into the application. You
 can create an additional, already activated user using this command:
 
 ```bash
-docker exec -ti penpot-penpot-backend_1 ./manage.sh create-profile
+docker exec -ti penpot_penpot-backend_1 ./manage.sh create-profile -u "Your Email" -p "Your Password" -n "Your Full Name"
 ```
 
 **NOTE:** take care that the container name depends of many factors.


### PR DESCRIPTION
I found this command requires 3 arguments in order to succeed. I've documented that here.