### PR TITLE
Update getting-started.md

### DIFF
--- a/technical-guide/getting-started.md
+++ b/technical-guide/getting-started.md
@@ -124,7 +124,7 @@ need to create a user in order be able login into the application. You
 can create an additional, already activated user using this command:
 
 ```bash
-docker exec -ti penpot_penpot-backend_1 ./manage.sh create-profile -u "Your Email" -p "Your Password" -n "Your Full Name"
+docker exec -ti penpot-penpot-backend-1 ./manage.sh create-profile -u "Your Email" -p "Your Password" -n "Your Full Name"
 ```
 
 **NOTE:** take care that the container name depends of many factors.


### PR DESCRIPTION
The Penpot command to add email access via the command line didn't work as the docker backend image name was different to the documentation.

Using `docker ps` made me aware of the issue.

```
CONTAINER ID   IMAGE                       COMMAND                  CREATED              STATUS              PORTS                  NAMES
77b17305e4fa   penpotapp/backend:latest    "/bin/bash run.sh"       About a minute ago   Up About a minute                          penpot-penpot-backend-1
```