### PR TITLE
🐛 fix-bugs-with-content-on-small-device-and-small-design-changes

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -511,6 +511,7 @@ a[href].direct-link:focus:visited,
   position: sticky;
   top: 8rem;
   align-self: start;
+  max-width: 320px;
 }
 .main-container .sidebar a[href] {
   color: var(--darkest);
@@ -621,7 +622,7 @@ a[href].direct-link:focus:visited,
 
 #search-results {
   background: white;
-  border: 1px solid var(--graylight);
+  border: 1px solid var(--color-gray-medium);
   list-style: none;
   margin: 0;
   padding: 0;
@@ -656,11 +657,11 @@ a[href].direct-link:focus:visited,
 
 #no-results-found {
   background: white;
-  border: 1px solid var(--graylight);
-  color: var(--graymedium);
+  border: 1px solid var(--color-gray-medium);
+  color: var(--color-gray-dark);
   list-style: none;
   margin: 0;
-  padding: 2rem;
+  padding: 1rem 2rem;
   box-shadow: 0 0 10px rgba(68, 68, 68, 0.1);
   width: 18rem;
 }
@@ -756,11 +757,11 @@ a[href].direct-link:focus:visited,
 }
 .help-sections > li.github a:hover h3 {
   color: var(--primarydark);
-  transition: color 200ms ease-in-out;
+  transition: color 50ms ease-in-out;
 }
 .help-sections > li.github a:hover svg {
   fill: var(--primarydark);
-  transition: fill 300ms ease-in-out;
+  transition: fill 50ms ease-in-out;
 }
 .help-sections > li.github a {
   display: flex;


### PR DESCRIPTION
This PR fixes issues with content overlay on small devices together with small design changes
### Shortened a long animation that felt strange compared to the rest
You can see this when you hover on "Collaborate at Github" on homepage.
### Search list has now colors from new palette
+ reduced vertical spacing for empty state - on screenshot below.

**before**:
![search-before](https://user-images.githubusercontent.com/28909808/218496266-839db2ab-f0d5-4258-90a3-a4754cdf99b4.jpg)

**after**
![after](https://user-images.githubusercontent.com/28909808/218496498-ac17eaf5-5331-43b6-aabb-4c3c92157b6d.jpg)

### Content overlay fix
![content-fix](https://user-images.githubusercontent.com/28909808/218497255-4b985d71-0f2d-4737-8755-1132bb88ffc2.jpg)

<hr>

### Footer change?
There is also space for improving footer (as you can see on the image below), where on small displays can have different layout. 

**Footer before**:
![footer-before](https://user-images.githubusercontent.com/28909808/218497874-d366d58a-f64d-4ec8-9117-fdd95e20e48a.jpg)

**Possible changes**:
![footer-after](https://user-images.githubusercontent.com/28909808/218498218-57d44b76-00cb-4776-a2bc-b2b64f157086.jpg)

Let me know if you are interested in footer change, and I can do it.


