### PR TITLE
📚 Add backend and exporter configuration to the documentation

### DIFF
--- a/technical-guide/configuration.md
+++ b/technical-guide/configuration.md
@@ -391,6 +391,16 @@ variable:
 PENPOT_FLAGS="$PENPOT_FLAGS enable-demo-warning"
 ```
 
+### Container Communication ###
+
+To connect the frontend to the exporter and backend, you need to fill out these environment variables.
+
+```bash
+# Frontend
+BACKEND_URL=http://your-penpot-backend
+EXPORT_URL=http://your-penpot-exporter
+```
+
 
 ## Exporter ##
 


### PR DESCRIPTION
This PR adds backend and exporter configuration to the documentation, for the `frontend` docker image.
The feature PR is [here](https://github.com/penpot/penpot/pull/2985)