### PR TITLE
Provide alternative to wget because not installed on Mac

### DIFF
--- a/technical-guide/getting-started.md
+++ b/technical-guide/getting-started.md
@@ -149,6 +149,10 @@ target="_blank">from Penpot repository</a>.
 ```bash
 wget https://raw.githubusercontent.com/penpot/penpot/main/docker/images/docker-compose.yaml
 ```
+or
+```bash
+curl -o docker-compose.yaml https://raw.githubusercontent.com/penpot/penpot/main/docker/images/docker-compose.yaml
+```
 
 Then simply launch composer:
 


### PR DESCRIPTION
Here's a simple alternative to wget to help people using a Mac because it is not available by default on MacOS.