### PR TITLE
Fix python binary not in path when creating new user

### DIFF
--- a/technical-guide/getting-started.md
+++ b/technical-guide/getting-started.md
@@ -186,7 +186,7 @@ If you have registration disabled, you can create additional profiles using the
 command line interface:
 
 ```bash
-docker exec -ti penpot-penpot-backend-1 python ./manage.py create-profile
+docker exec -ti penpot-penpot-backend-1 python3 ./manage.py create-profile
 ```
 
 **NOTE:** the exact container name depends on your docker version and platform.


### PR DESCRIPTION
This pull request fixes the example command for creating a new user by specifiying a python binary that is actually in the path.