### PR TITLE
docs: fix typo an board -> a board

### DIFF
--- a/user-guide/layer-basics/index.njk
+++ b/user-guide/layer-basics/index.njk
@@ -122,7 +122,7 @@ title: 04· Layer basics
 <p>Groups and boards can have their contents expanded and collapsed. Click on the arrow at the
 right side to toggle the visibility of their contents. </p>
 <p>To collapse all the layers, and just display the boards,
-press <kbd>Shift/⇧</kbd> + left click over the right arrow of a group or an board to collapse them all.</p>
+press <kbd>Shift/⇧</kbd> + left click over the right arrow of a group or a board to collapse them all.</p>
 <p><img src="/img/collapsing-groups.gif" alt="Collapsing groups and boards" /></p>
 
 <h3 id="boolean-operators">Boolean operators</h3>

--- a/user-guide/objects/index.njk
+++ b/user-guide/objects/index.njk
@@ -13,7 +13,7 @@ available in Penpot, and how to get the most of them.</p>
 <p>You can create a board using the board tool at the toolbar or the shortcut <kbd>B</kbd>. </p>
 <p>Set a custom size or choose one of the provided presets with the most common resolution for devices and standard print sizes. </p>
 <p><img src="/img/board-create.gif" alt="boards" /></p>
-<p><strong>TIP:</strong> Create an board around one or more selected objects using the option at the menu or the shortcut <kbd>Ctrl/⌘</kbd> + <kbd>Alt</kbd> + <kbd>G</kbd>.</p>
+<p><strong>TIP:</strong> Create a board around one or more selected objects using the option at the menu or the shortcut <kbd>Ctrl/⌘</kbd> + <kbd>Alt</kbd> + <kbd>G</kbd>.</p>
 
 <h4>Select boards</h4>
 <p>There are two different cases in terms of selecting boards:</p>
@@ -46,7 +46,7 @@ available in Penpot, and how to get the most of them.</p>
 <p><img src="/img/board-show-viewmode.png" alt="boards" /></p>
 
 <h4>Show fill in exports</h4>
-<p>You can also decide if the fill of an artboard will be shown in exports. ­	
+<p>You can also decide if the fill of an artboard will be shown in exports. ­
 Sometimes you don’t need the artboards to be part of your designs, but only their support to work on them.</p>
 <p><img src="/img/board-show-fill.png" alt="boards" /></p>
 

--- a/user-guide/prototyping/index.njk
+++ b/user-guide/prototyping/index.njk
@@ -39,7 +39,7 @@ title: 11· Prototyping
   <li><strong>On click:</strong> when user clicks or tap the hotspot.</li>
   <li><strong>Mouse enter:</strong> when the mouse enter the hotspot area.</li>
   <li><strong>Mouse leave:</strong> when the mouse leaves the hotspot area.</li>
-  <li><strong>After delay:</strong> when a certain time has passed after an board is shown. Note: this can only be set at boards.</li>
+  <li><strong>After delay:</strong> when a certain time has passed after a board is shown. Note: this can only be set at boards.</li>
 </ul>
 
 <h3 id="prototyping-actions">Interaction actions</h3>
@@ -58,7 +58,7 @@ title: 11· Prototyping
 <p>The classic, most usual of the prototyping actions. It takes the user to one board to the one that is being set in the interaction.</p>
 
 <h4 id="prototyping-actions-overlay">Open overlay</h4>
-<p>It opens an board right over the current board. This action is typically used to display tooltips, modal windows or notifications.</p>
+<p>It opens a board right over the current board. This action is typically used to display tooltips, modal windows or notifications.</p>
 <p><img src="/img/prototyping-overlay.gif" alt="prototyping" /></p>
 <p>You have several presets for positioning the overlay (center, top left, top right...) but you can also do it manually. Just select the “Manual” option and drag the “ghost” (an area with the size of the destination board) to the place you want the overlay to show up.</p>
 <p>There are also a couple of options that facilitates to mimic typical overlay behaviours:</p>
@@ -130,13 +130,13 @@ title: 11· Prototyping
 
 
 <h4 id="prototyping-flows-starting">Starting points</h4>
-<p><strong>A starting point</strong> is an board selected to be the first screen of a flow. You could set an board as a starting point just because you want this board to be the first one to be shown in the view mode, but you can also set more starting points to define different user journeys.</p>
+<p><strong>A starting point</strong> is a board selected to be the first screen of a flow. You could set a board as a starting point just because you want this board to be the first one to be shown in the view mode, but you can also set more starting points to define different user journeys.</p>
 <p>There are several ways to create starting points:</p>
 <ul>
-  <li><strong>Automatically</strong>: when creating a connection from an board which is not connected yet (meaning that it does not belong to an existing flow), the origin board will be set as a flow start.
+  <li><strong>Automatically</strong>: when creating a connection from a board which is not connected yet (meaning that it does not belong to an existing flow), the origin board will be set as a flow start.
 <p><img src="/img/prototyping-flows-connection.gif" alt="prototyping" /></p>
 </li>
-  <li><strong>From the prototype sidebar</strong>: having an board selected, click on the “+” button to set it as a flow start.
+  <li><strong>From the prototype sidebar</strong>: having a board selected, click on the “+” button to set it as a flow start.
 <p><img src="/img/prototyping-flows-start.gif" alt="prototyping" /></p>
 </li>
   <li><strong>From the board menu</strong>.

--- a/user-guide/view-mode/index.njk
+++ b/user-guide/view-mode/index.njk
@@ -11,7 +11,7 @@ title: 12· View mode
 
 <h3 id="viewmode-launch">Launch your designs in View mode</h3>
 <p>To view your designs from the workspace at View mode click the play button at the top right of the navbar or press <kbd>G</kbd> <kbd>V</kbd>.</p>
-<p><strong>Note:</strong> the View mode shows only boards and their contents. Anything outside an board will not be shown at the View mode.</p>
+<p><strong>Note:</strong> the View mode shows only boards and their contents. Anything outside a board will not be shown at the View mode.</p>
 <p><img src="/img/viewmode-play.png" alt="viewmode" /></p>
 
 <h3 id="viewmode-features">Features and options</h3>

--- a/user-guide/workspace-basics/index.njk
+++ b/user-guide/workspace-basics/index.njk
@@ -6,7 +6,7 @@ title: 03· Workspace basics
 <p class="main-paragraph">The Workspace is where you create designs. You have an infinite canvas in where you can directly work but you also have the ability to create pages and boards that will help you to create exportable components.</p>
 
 <h2 id="viewport">The viewport</h2>
-<p>Surrounded by panels, header and toolbars, in the middle of the workspace, you can find the viewport. The viewport is the design area of a file page. It is practically infinite. If what you need is a frame with specific, limited dimensions, you can create an board.</p>
+<p>Surrounded by panels, header and toolbars, in the middle of the workspace, you can find the viewport. The viewport is the design area of a file page. It is practically infinite. If what you need is a frame with specific, limited dimensions, you can create a board.</p>
 <p><img src="/img/viewport.png" alt="the viewport" /></p>
 <h4>Navigate the viewport</h4>
 <p>Press <kbd>space</kbd> while moving your mouse to navigate the viewport. If you are using a trackpad you can do two finger scrolling.</p>


### PR DESCRIPTION
I was reading through the documentation but ran into a small typo.
In English, `a` vs `an` depends on if the next word starts with the sound of a vowel.

For example:

* a dashboard
* a board
* a group
* a layer
* an image
* an action
* an app
* an intersection