### PR TITLE
Fix broken link in Libraries guide

### DIFF
--- a/user-guide/libraries/index.njk
+++ b/user-guide/libraries/index.njk
@@ -23,7 +23,7 @@ title: 09· Asset Libraries
 <ul>
   <li><strong>Components:</strong> Each Main Component is automatically stored in the library so there is no button or specific action to do it. Learn more about components at the <a href="/user-guide/components/">components section</a>.</li>
   <li><strong>Graphics:</strong> Click the “+” to inspect your local files and choose one or more images to upload them to the library.</li>
-  <li><strong>Colors:</strong> Click the “+” to launch the color picker and add a color to the library. Learn more about <a href="/user-guide/color/">managing color</a>.</li>
+  <li><strong>Colors:</strong> Click the “+” to launch the color picker and add a color to the library. Learn more about <a href="/user-guide/styling/#color-picker">managing color</a>.</li>
   <li><strong>Typographies:</strong> All typography styles created from the text properties (at the right sidebar) are automatically stored at the library. You can also click the “+” to create a new typography style from scratch.</li>
 </ul>
 <p><img src="/img/assets-add.gif" alt="libraries" /></p>


### PR DESCRIPTION
The referenced page was removed in commit 11d5756a5be75444c57d4de4d7b4b7baf1e8270a and its contents put in the Libraries guide.