### PR TITLE
minor fix: "Dev Env" link lead to "Architecture" page instead

### DIFF
--- a/technical-guide/developer/index.md
+++ b/technical-guide/developer/index.md
@@ -10,7 +10,7 @@ of Penpot application.
 The [Architecture][1] and [Data model][2] sections provide a bird's eye view of
 the whole system, to better understand how is structured.
 
-The [Dev Env][1] section explains how to setup the development enviroment that
+The [Dev Env][3] section explains how to setup the development enviroment that
 we (the core team) use internally.
 
 And the rest of sections are a list categorized of probably not deeply


### PR DESCRIPTION
changed
`[Dev Env][1]`
linking to
`[1]: /technical-guide/developer/architecture/`

to
`[Dev Env][3]`
linking to
`[3]: /technical-guide/developer/devenv/`