### PR TITLE
fix for manage.sh no longer existing

### DIFF
--- a/technical-guide/getting-started.md
+++ b/technical-guide/getting-started.md
@@ -190,7 +190,7 @@ If you have registration disabled, you can create additional profiles using the
 command line interface:
 
 ```bash
-docker exec -ti penpot-penpot-backend-1 bash ./manage.sh create-profile
+docker exec -ti penpot-penpot-backend-1 python3 ./manage.py create-profile
 ```
 
 **NOTE:** the exact container name depends on your docker version and platform.


### PR DESCRIPTION
Changed command for creating a user to use python and manage.py, as the bash script is no longer present.

Image for context:

![image](https://github.com/penpot/penpot-docs/assets/582149/ad9f7fcd-f4d3-44c6-84f7-d0babf11551b)
