### PR TITLE
Updated manual user registration documentation

### DIFF
--- a/technical-guide/getting-started.md
+++ b/technical-guide/getting-started.md
@@ -190,7 +190,7 @@ If you have registration disabled, you can create additional profiles using the
 command line interface:
 
 ```bash
-docker exec -ti penpot-penpot-backend-1 bash ./manage.sh create-profile
+docker exec -ti penpot-penpot-backend-1 python3 ./manage.py create-profile
 ```
 
 **NOTE:** the exact container name depends on your docker version and platform.


### PR DESCRIPTION
Hi, I am not sure if this is an old code snippet for v1, but having logged in to the Docker root folder for the backend, I have noticed there are no `manage.sh` file but instead there is a `manage.py` 


this should fix the documentation, for future reference