### PR TITLE
added kubernetes deployment option on self-hosted unofficial options

### DIFF
--- a/technical-guide/getting-started.md
+++ b/technical-guide/getting-started.md
@@ -263,6 +263,7 @@ There are some other options, **NOT SUPPORTED BY PENPOT**:
 
 * Install with <a href="https://community.penpot.app/t/how-to-develop-penpot-with-podman-penpotman/2113" target="_blank">Podman</a> instead of Docker.
 * Try the under development <a href="https://community.penpot.app/t/introducing-penpot-desktop/1468" target="_blank">Penpot Desktop app</a>.
+* Try a simple Kubernetes Deployment option <a href="https://github.com/degola/penpot-kubernetes" target="_blank">penpot-kubernetes</a>.
 * Or try a fully manual installation if you have really special needs. For help, you can look at the [Architecture][2] section and the <a href="https://github.com/penpot/penpot/tree/develop/docker/images" target="_blank">Docker configuration files</a>.
 
 [1]: /technical-guide/configuration/


### PR DESCRIPTION
I just published a small skeleton to deploy Penpot on Kubernetes, read more on Medium: https://medium.com/@degola/deploying-figma-alternative-penpot-on-kubernetes-059fdce81497