### PR TITLE
:sparkles: changed the id of h1 "Asset Libraries" because it had the …

### DIFF
--- a/user-guide/libraries/index.njk
+++ b/user-guide/libraries/index.njk
@@ -2,7 +2,7 @@
 title: 09· Asset Libraries
 ---
 
-<h1 id="libraries">Asset Libraries</h1>
+<h1 id="asset-libraries">Asset Libraries</h1>
 <p class="main-paragraph">Asset Libraries allow you to store elements and styles so that they can be easily reused. Libraries may include components, graphics, colors and typographies. Learn how to create and manage them to better organize the pieces of your designs and speed your workflow.</p>
 
 <h2 id="assets">Assets</h2>


### PR DESCRIPTION
…same id as h2 "Libraries"

This meant that when navigating the docs, if you click the subsection "Libraries" (a subsection of "Asset Libraries") it takes you back to the top of the section