### PR TITLE
:books: include steps to follow if there are no shared libraries yet

### DIFF
--- a/user-guide/libraries/index.njk
+++ b/user-guide/libraries/index.njk
@@ -176,7 +176,7 @@ title: 09· Asset Libraries
 </figure>
 
 <h4>Connect shared libraries</h4>
-<p>To add a Shared Library from another file, launch the libraries panel, then search and select the available libraries.</p>
+<p>To add a Shared Library from another file, launch the libraries panel, then search and select the available libraries. If you see the message "There are no Shared Libraries available", start by <a href="/user-guide/libraries/#shared-libraries">publishing other files as a shared library</a> or add from our <a href="https://penpot.app/libraries-templates">Libraries & templates</a>.</p>
 <figure>
   <video title="Connecting a shared library" muted="" playsinline="" controls="" width="100%" poster="/img/libraries/libraries-launch.webp" height="auto">
     <source src="/img/libraries/libraries-launch.mp4" type="video/mp4">


### PR DESCRIPTION
For some users who may just be getting started with the app, if they don't already see libraries there to connect, it's not clear how to proceed