### PR TITLE
:books: Update docs to new docker-compose style

### DIFF
--- a/technical-guide/configuration.md
+++ b/technical-guide/configuration.md
@@ -26,34 +26,34 @@ This section will list all common configuration between backend and frontend.
 
 There are two types of configuration: options (properties that require some value) and
 flags (that just enables or disables something). All flags are set in a single
-<code class="language-bash">PENPOT_FLAGS</code> environment variable will have an ordered list of strings using this
-format: <code class="language-bash"><enable|disable>-\<flag-name></code>.
+<code class="language-bash">PENPOT_FLAGS</code> environment variable. The envvar is a list of strings using this
+format: <code class="language-bash"><enable|disable>-\<flag-name></code>. For example:
 
+```bash
+PENPOT_FLAGS: enable-smpt disable-registration disable-email-verification
+```
 
 ### Registration ###
 
-Penpot comes with an option to completely disable the registration process or restrict it
-to some domains.
-
-If you want to completely disable registration, use the following variable in both
-frontend & backend:
+Penpot comes with an option to completely disable the registration process;
+for this, use the following variable:
 
 ```bash
-PENPOT_FLAGS="$PENPOT_FLAGS disable-registration"
+PENPOT_FLAGS: [...] disable-registration
 ```
 
-You also can restrict the registrations to a closed list of domains:
+You may also want to restrict the registrations to a closed list of domains:
 
 ```bash
 # comma separated list of domains (backend only)
-PENPOT_REGISTRATION_DOMAIN_WHITELIST=""
+PENPOT_REGISTRATION_DOMAIN_WHITELIST:
 
-# OR
-PENPOT_EMAIL_DOMAIN_WHITELIST=path/to/whitelist.txt
+# OR (backend only)
+PENPOT_EMAIL_DOMAIN_WHITELIST: path/to/whitelist.txt
 ```
 
 **NOTE**: Since version 2.1, email whitelisting should be explicitly
-enabled with <code class="language-bash">enable-email-whitelist</code>. For backward compatibility, we
+enabled with <code class="language-bash">enable-email-whitelist</code> flag. For backward compatibility, we
 autoenable it when <code class="language-bash">PENPOT_REGISTRATION_DOMAIN_WHITELIST</code> is set with
 not-empty content.
 
@@ -67,13 +67,13 @@ testing or demonstration purposes.
 You can enable demo users using the following variable:
 
 ```bash
-PENPOT_FLAGS="$PENPOT_FLAGS enable-demo-users"
+PENPOT_FLAGS: [...] enable-demo-users
 ```
 
 ### Authentication Providers
 
 To configure the authentication with third-party auth providers you will need to
-configure penpot and set the correct callback of your penpot instance in the auth-provider
+configure Penpot and set the correct callback of your Penpot instance in the auth-provider
 configuration.
 
 The callback has the following format:
@@ -92,17 +92,17 @@ https://<your_domain>/api/auth/oauth/gitlab/callback
 
 #### Penpot
 
-Consists on registration and authentication via password. It is enabled by default, but can
-be disabled with the following flags:
+Consists on registration and authentication via email / password. It is enabled by default,
+but login can be disabled with the following flags:
 
 ```bash
-PENPOT_FLAGS="[...] disable-login-with-password"
+PENPOT_FLAGS: [...] disable-login-with-password
 ```
 
 And the registration also can be disabled with:
 
 ```bash
-PENPOT_FLAGS="[...] disable-registration"
+PENPOT_FLAGS: [...] disable-registration
 ```
 
 
@@ -111,12 +111,11 @@ PENPOT_FLAGS="[...] disable-registration"
 Allows integrating with Google as OAuth provider:
 
 ```bash
-# Backend & Frontend
-PENPOT_FLAGS="[...] enable-login-with-google"
+PENPOT_FLAGS: [...] enable-login-with-google
 
 # Backend only:
-PENPOT_GOOGLE_CLIENT_ID=<client-id>
-PENPOT_GOOGLE_CLIENT_SECRET=<client-secret>
+PENPOT_GOOGLE_CLIENT_ID: <client-id>
+PENPOT_GOOGLE_CLIENT_SECRET: <client-secret>
 ```
 
 #### GitLab
@@ -124,13 +123,12 @@ PENPOT_GOOGLE_CLIENT_SECRET=<client-secret>
 Allows integrating with GitLab as OAuth provider:
 
 ```bash
-# Backend & Frontend
-PENPOT_FLAGS="[...] enable-login-with-gitlab"
+PENPOT_FLAGS: [...] enable-login-with-gitlab
 
 # Backend only
-PENPOT_GITLAB_BASE_URI=https://gitlab.com
-PENPOT_GITLAB_CLIENT_ID=<client-id>
-PENPOT_GITLAB_CLIENT_SECRET=<client-secret>
+PENPOT_GITLAB_BASE_URI: https://gitlab.com
+PENPOT_GITLAB_CLIENT_ID: <client-id>
+PENPOT_GITLAB_CLIENT_SECRET: <client-secret>
 ```
 
 #### GitHub
@@ -138,12 +136,11 @@ PENPOT_GITLAB_CLIENT_SECRET=<client-secret>
 Allows integrating with GitHub as OAuth provider:
 
 ```bash
-# Backend & Frontend
-PENPOT_FLAGS="[...] enable-login-with-github"
+PENPOT_FLAGS: [...] enable-login-with-github
 
 # Backend only
-PENPOT_GITHUB_CLIENT_ID=<client-id>
-PENPOT_GITHUB_CLIENT_SECRET=<client-secret>
+PENPOT_GITHUB_CLIENT_ID: <client-id>
+PENPOT_GITHUB_CLIENT_SECRET: <client-secret>
 ```
 
 #### OpenID Connect
@@ -156,29 +153,28 @@ protocol (usually used for SSO).
 All the other options are backend only:
 
 ```bash
-## Frontend & Backend
-PENPOT_FLAGS="[...] enable-login-with-oidc"
+PENPOT_FLAGS: [...] enable-login-with-oidc
 
 ## Backend only
-PENPOT_OIDC_CLIENT_ID=<client-id>
+PENPOT_OIDC_CLIENT_ID: <client-id>
 
 # Mainly used for auto discovery the openid endpoints
-PENPOT_OIDC_BASE_URI=<uri>
-PENPOT_OIDC_CLIENT_SECRET=<client-id>
+PENPOT_OIDC_BASE_URI: <uri>
+PENPOT_OIDC_CLIENT_SECRET: <client-id>
 
 # Optional backend variables, used mainly if you want override; they are
 # autodiscovered using the standard openid-connect mechanism.
-PENPOT_OIDC_AUTH_URI=<uri>
-PENPOT_OIDC_TOKEN_URI=<uri>
-PENPOT_OIDC_USER_URI=<uri>
+PENPOT_OIDC_AUTH_URI: <uri>
+PENPOT_OIDC_TOKEN_URI: <uri>
+PENPOT_OIDC_USER_URI: <uri>
 
 # Optional list of roles that users are required to have. If no role
 # is provided, roles checking  disabled.
-PENPOT_OIDC_ROLES="role1 role2"
+PENPOT_OIDC_ROLES: "role1 role2"
 
 # Attribute to use for lookup roles on the user object. Optional, if
 # not provided, the roles checking will be disabled.
-PENPOT_OIDC_ROLES_ATTR=
+PENPOT_OIDC_ROLES_ATTR:
 ```
 <br />
 
@@ -188,9 +184,9 @@ Added the ability to specify custom OIDC scopes.
 
 ```bash
 # This settings allow overwrite the required scopes, use with caution
-# because penpot requres at least `name` and `email` attrs found on the
+# because Penpot requres at least `name` and `email` attrs found on the
 # user info. Optional, defaults to `openid profile`.
-PENPOT_OIDC_SCOPES="scope1 scope2"
+PENPOT_OIDC_SCOPES: "scope1 scope2"
 ```
 <br />
 
@@ -202,11 +198,11 @@ the userinfo object for the profile creation.
 ```bash
 # Attribute to use for lookup the name on the user object. Optional,
 # if not perovided, the `name` prop will be used.
-PENPOT_OIDC_NAME_ATTR=
+PENPOT_OIDC_NAME_ATTR:
 
 # Attribute to use for lookup the email on the user object. Optional,
 # if not perovided, the `email` prop will be used.
-PENPOT_OIDC_EMAIL_ATTR=
+PENPOT_OIDC_EMAIL_ATTR:
 ```
 <br />
 
@@ -222,7 +218,7 @@ endpoint.
 # Set the default USER INFO source. Can be `token` or `userinfo`. By default
 # is unset (both will be tried, starting with token).
 
-PENPOT_OIDC_USER_INFO_SOURCE=
+PENPOT_OIDC_USER_INFO_SOURCE:
 ```
 <br />
 
@@ -232,7 +228,7 @@ Allows users to register and login with oidc without having to previously
 register with another method.
 
 ```bash
-PENPOT_FLAGS="[...] enable-oidc-registration"
+PENPOT_FLAGS: [...] enable-oidc-registration
 ```
 
 
@@ -242,11 +238,11 @@ Allows integrating with Azure Active Directory as authentication provider:
 
 ```bash
 # Backend & Frontend
-PENPOT_OIDC_CLIENT_ID=<client-id>
+PENPOT_OIDC_CLIENT_ID: <client-id>
 
 ## Backend only
-PENPOT_OIDC_BASE_URI=https://login.microsoftonline.com/<tenant-id>/v2.0/
-PENPOT_OIDC_CLIENT_SECRET=<client-secret>
+PENPOT_OIDC_BASE_URI: https://login.microsoftonline.com/<tenant-id>/v2.0/
+PENPOT_OIDC_CLIENT_SECRET: <client-secret>
 ```
 
 ### LDAP ###
@@ -255,22 +251,21 @@ Penpot comes with support for *Lightweight Directory Access Protocol* (LDAP). Th
 example configuration we use internally for testing this authentication backend.
 
 ```bash
-## Backend & Frontend
-PENPOT_FLAGS="$PENPOT_FLAGS enable-login-with-ldap"
+PENPOT_FLAGS: [...] enable-login-with-ldap
 
 ## Backend only
-PENPOT_LDAP_HOST=ldap
-PENPOT_LDAP_PORT=10389
-PENPOT_LDAP_SSL=false
-PENPOT_LDAP_STARTTLS=false
-PENPOT_LDAP_BASE_DN=ou=people,dc=planetexpress,dc=com
-PENPOT_LDAP_BIND_DN=cn=admin,dc=planetexpress,dc=com
-PENPOT_LDAP_BIND_PASSWORD=GoodNewsEveryone
-PENPOT_LDAP_USER_QUERY=(&(|(uid=:username)(mail=:username))(memberOf=cn=penpot,ou=groups,dc=my-domain,dc=com))
-PENPOT_LDAP_ATTRS_USERNAME=uid
-PENPOT_LDAP_ATTRS_EMAIL=mail
-PENPOT_LDAP_ATTRS_FULLNAME=cn
-PENPOT_LDAP_ATTRS_PHOTO=jpegPhoto
+PENPOT_LDAP_HOST: ldap
+PENPOT_LDAP_PORT: 10389
+PENPOT_LDAP_SSL: false
+PENPOT_LDAP_STARTTLS: false
+PENPOT_LDAP_BASE_DN: ou=people,dc=planetexpress,dc=com
+PENPOT_LDAP_BIND_DN: cn=admin,dc=planetexpress,dc=com
+PENPOT_LDAP_BIND_PASSWORD: GoodNewsEveryone
+PENPOT_LDAP_USER_QUERY: (&(|(uid=:username)(mail=:username))(memberOf=cn=penpot,ou=groups,dc=my-domain,dc=com))
+PENPOT_LDAP_ATTRS_USERNAME: uid
+PENPOT_LDAP_ATTRS_EMAIL: mail
+PENPOT_LDAP_ATTRS_FULLNAME: cn
+PENPOT_LDAP_ATTRS_PHOTO: jpegPhoto
 ```
 
 If you miss something, please open an issue and we discuss it.
@@ -290,48 +285,54 @@ Essential database configuration:
 
 ```bash
 # Backend
-PENPOT_DATABASE_USERNAME=penpot
-PENPOT_DATABASE_PASSWORD=penpot
-PENPOT_DATABASE_URI=postgresql://127.0.0.1/penpot
+PENPOT_DATABASE_USERNAME: penpot
+PENPOT_DATABASE_PASSWORD: penpot
+PENPOT_DATABASE_URI: postgresql://127.0.0.1/penpot
 ```
 
-The username and password are optional.
+The username and password are optional. These settings should be compatible with the ones
+in the postgres configuration:
 
+```bash
+# Postgres
+POSTGRES_DATABASE: penpot
+POSTGRES_USER: penpot
+POSTGRES_PASSWORD: penpot
+```
 
 ### Email (SMTP)
 
-By default, when no SMTP (email) is configured, the email will be printed to the console,
-which means that the emails will be shown in the stdout.
+By default, <code class="language-bash">smpt</code> flag is disabled, the email will be
+printed to the console, which means that the emails will be shown in the stdout.
 
 Note that if you plan to invite members to a team, it is recommended that you enable SMTP
 as they will need to login to their account after recieving the invite link sent an in email.
 It is currently not possible to just add someone to a team without them accepting an
 invatation email.
 
-If you have an SMTP service,
-uncomment the appropriate settings section in <code class="language-bash">docker-compose.yml</code> and configure those
+If you have an SMTP service, uncomment the appropriate settings section in
+<code class="language-bash">docker-compose.yml</code> and configure those
 environment variables.
 
 Setting up the default FROM and REPLY-TO:
 
 ```bash
 # Backend
-PENPOT_SMTP_DEFAULT_REPLY_TO=Penpot <no-reply@example.com>
-PENPOT_SMTP_DEFAULT_FROM=Penpot <no-reply@example.com>
+PENPOT_SMTP_DEFAULT_REPLY_TO: Penpot <no-reply@example.com>
+PENPOT_SMTP_DEFAULT_FROM: Penpot <no-reply@example.com>
 ```
 
 Enable SMTP:
 
 ```bash
+PENPOT_FLAGS: [...] enable-smtp
 # Backend
-PENPOT_FLAGS="[...] enable-smtp"
-PENPOT_SMTP_HOST=<host>
-PENPOT_SMTP_PORT=587
-PENPOT_SMTP_USERNAME=<username>
-PENPOT_SMTP_PASSWORD=<password>
-PENPOT_SMTP_TLS=true
+PENPOT_SMTP_HOST: <host>
+PENPOT_SMTP_PORT: 587
+PENPOT_SMTP_USERNAME: <username>
+PENPOT_SMTP_PASSWORD: <password>
+PENPOT_SMTP_TLS: true
 ```
-
 
 ### Storage
 
@@ -347,8 +348,8 @@ configuration looks like this:
 
 ```bash
 # Backend
-PENPOT_ASSETS_STORAGE_BACKEND=assets-fs
-PENPOT_STORAGE_ASSETS_FS_DIRECTORY=/opt/data/assets
+PENPOT_ASSETS_STORAGE_BACKEND: assets-fs
+PENPOT_STORAGE_ASSETS_FS_DIRECTORY: /opt/data/assets
 ```
 
 The main downside of this backend is the hard dependency on nginx approach to serve files
@@ -369,16 +370,16 @@ This is how configuration looks for S3 backend:
 
 ```bash
 # AWS Credentials
-AWS_ACCESS_KEY_ID=<you-access-key-id-here>
-AWS_SECRET_ACCESS_KEY=<your-secret-access-key-here>
+AWS_ACCESS_KEY_ID: <you-access-key-id-here>
+AWS_SECRET_ACCESS_KEY: <your-secret-access-key-here>
 
 # Backend configuration
-PENPOT_ASSETS_STORAGE_BACKEND=assets-s3
-PENPOT_STORAGE_ASSETS_S3_REGION=<aws-region>
-PENPOT_STORAGE_ASSETS_S3_BUCKET=<bucket-name>
+PENPOT_ASSETS_STORAGE_BACKEND: assets-s3
+PENPOT_STORAGE_ASSETS_S3_REGION: <aws-region>
+PENPOT_STORAGE_ASSETS_S3_BUCKET: <bucket-name>
 
 # Optional if you want to use it with non AWS, S3 compatible service:
-PENPOT_STORAGE_ASSETS_S3_ENDPOINT=<endpoint-uri>
+PENPOT_STORAGE_ASSETS_S3_ENDPOINT: <endpoint-uri>
 ```
 
 ### Redis
@@ -388,7 +389,7 @@ mainly for websocket notifications coordination.
 
 ```bash
 # Backend
-PENPOT_REDIS_URI=redis://localhost/0
+PENPOT_REDIS_URI: redis://localhost/0
 ```
 
 If you are using the official docker compose file, this is already configured.
@@ -396,21 +397,12 @@ If you are using the official docker compose file, this is already configured.
 
 ### HTTP
 
-You can set the port where the backend http server will listen for requests.
+You will need to set the <code class="language-bash">PENPOT_PUBLIC_URI</code> environment
+variable in case you go to serve Penpot to the users; it should point to public URI
+where users will access the application:
 
 ```bash
-# Backend
-PENPOT_HTTP_SERVER_PORT=6060
-PENPOT_HTTP_SERVER_HOST=localhost
-```
-
-Additionally, you probably will need to set the <code class="language-bash">PENPOT_PUBLIC_URI</code> environment variable
-in case you go to serve penpot to the users, and it should point to public URI where users
-will access the application:
-
-```bash
-# Backend
-PENPOT_PUBLIC_URI=http://localhost:9001
+PENPOT_PUBLIC_URI: http://localhost:9001
 ```
 
 ## Frontend ##
@@ -432,8 +424,8 @@ To connect the frontend to the exporter and backend, you need to fill out these 
 
 ```bash
 # Frontend
-PENPOT_BACKEND_URI=http://your-penpot-backend
-PENPOT_EXPORTER_URI=http://your-penpot-exporter
+PENPOT_BACKEND_URI: http://your-penpot-backend
+PENPOT_EXPORTER_URI: http://your-penpot-exporter
 ```
 
 These variables are used for generate correct nginx.conf file on container startup.
@@ -446,40 +438,25 @@ demonstration purpose instance (no backups, periodical data wipe, ...), set the 
 variable:
 
 ```bash
-# Frontend
-PENPOT_FLAGS="$PENPOT_FLAGS enable-demo-warning"
+PENPOT_FLAGS: [...] enable-demo-warning
 ```
-
-## Exporter ##
-
-The exporter application only have a single configuration option and it can be provided
-using environment variables in the same way as backend.
-
-
-```bash
-# Backend & Frontend
-PENPOT_PUBLIC_URI=http://public-domain
-```
-
-This environment variable indicates where the exporter can access to the public frontend
-application (because it uses special pages from it to render the shapes in the underlying
-headless web browser).
-
 
 ## Other flags
-- <code class="language-bash">enable-cors</code> : Enables the default cors cofiguration that allows all domains (this
-  configuration is designed only for dev purposes right now)
-- <code class="language-bash">enable-backend-api-doc</code> : Enables the <code class="language-bash">/api/doc</code>  endpoint that lists all rpc methods
-  available on backend
-- <code class="language-bash">enable-insecure-register</code> : Enables the insecure process of profile registration
-  deactivating the email verification process (only for local or internal setups)
-- <code class="language-bash">disable-secure-session-cookies</code> : By default, penpot uses the <code class="language-bash">secure</code>  flag on cookies,
-  this flag disables it; it is usefull if you have plan to serve penpot under different
-  domain than <code class="language-bash">localhost</code>  without HTTPS
-- <code class="language-bash">disable-login-with-password</code> : allows disable password based login form
-- <code class="language-bash">disable-registration</code> : disables registration (still enabled for invitations only).
-- <code class="language-bash">enable-prepl-server</code> : enables PREPL server, used by manage.py and other additional
-  tools for communicate internally with penpot backend
+
+- <code class="language-bash">enable-cors</code>: Enables the default cors cofiguration that allows all domains
+  (this configuration is designed only for dev purposes right now)
+- <code class="language-bash">enable-backend-api-doc</code>: Enables the <code class="language-bash">/api/doc</code>
+  endpoint that lists all rpc methods available on backend
+- <code class="language-bash">disable-email-verification</code>: Deactivates the email verification process
+   (only recommended for local or internal setups)
+- <code class="language-bash">disable-secure-session-cookies</code>: By default, Penpot uses the
+  <code class="language-bash">secure</code> flag on cookies, this flag disables it;
+  it is useful if you plan to serve Penpot under different
+  domain than <code class="language-bash">localhost</code> without HTTPS
+- <code class="language-bash">disable-login-with-password</code>: allows disable password based login form
+- <code class="language-bash">disable-registration</code>: disables registration (still enabled for invitations only).
+- <code class="language-bash">enable-prepl-server</code>: enables PREPL server, used by manage.py and other additional
+  tools for communicate internally with Penpot backend
 
 __Since version 1.13.0__
 


### PR DESCRIPTION
This PR updates the documentation regarding configuration to adapt it to the new configuration flag style and other minor changes in docker-compose.yaml.

**Questions:**

1. The docs say "We autoenable it (enable-email-whitelist) when `PENPOT_REGISTRATION_DOMAIN_WHITELIST` is set with non-empty content.
Does Penpot autonable as well when the non-empty content is `PENPOT_EMAIL_DOMAIN_WHITELIST`?

2. Would it be difficult to deprecate `white` and `black` list in favour of `allow` and `deny` list?

